### PR TITLE
Support use of i18n middleware

### DIFF
--- a/lib/deep-translate.js
+++ b/lib/deep-translate.js
@@ -2,30 +2,33 @@
 
 const _ = require('lodash');
 
-module.exports = options => {
-  const translate = options.translate || _.identity;
-  function deepTranslate(key) {
+const Translator = (translate, req) => {
+  return function deepTranslate(key) {
     let translated = translate(key);
     if (_.isPlainObject(translated)) {
       translated = _.reduceRight(translated, (prev, item, tKey) => {
         let translationPath = key + '.' + tKey;
         let result;
-        if (_.isPlainObject(item) && this.sessionModel) {
-          let value = this.sessionModel.get(tKey);
+        if (_.isPlainObject(item) && req.sessionModel) {
+          let value = req.sessionModel.get(tKey);
           if (value) {
             value = value.toString();
           }
           translationPath += '.' + value;
         }
-        result = deepTranslate.call(this, translationPath);
+        result = deepTranslate(translationPath);
         return result !== translationPath ? result : prev;
       }, '');
     }
     return translated;
-  }
+  };
+};
 
+module.exports = options => {
+  options = options || {};
   return (req, res, next) => {
-    req.translate = deepTranslate.bind(req);
+    const translate = options.translate || req.translate || (a => a);
+    req.translate = Translator(translate, req);
     req.rawTranslate = translate;
     next();
   };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -35,13 +35,13 @@ module.exports = (options) => {
 
   const opts = options || {};
   const logger = opts.logger;
-  const translate = opts.translate;
   const debug = opts.debug;
 
   /* eslint no-unused-vars:0 */
   return (err, req, res, next) => {
     /* eslint no-unused-vars:1 */
 
+    const translate = opts.translate || req.translate;
     const content = getContent(err, translate);
 
     if (logger && logger.error) {

--- a/lib/not-found.js
+++ b/lib/not-found.js
@@ -19,10 +19,10 @@ module.exports = options => {
 
   const opts = options || {};
   const logger = opts.logger;
-  const translate = opts.translate;
 
   return (req, res) => {
 
+    const translate = opts.translate || req.translate;
     const translations = getTranslations(translate);
 
     if (logger && logger.warn) {

--- a/test/lib/deep-translate.js
+++ b/test/lib/deep-translate.js
@@ -3,18 +3,20 @@
 const deepTranslate = require('../../lib/deep-translate');
 
 describe('deepTranslate middleware', () => {
-  const req = {
-    sessionModel: {
-      get: sinon.stub()
-    }
-  };
-  const res = {};
+  let req;
+  let res;
   let locales;
   let middleware;
   let next;
   let translate;
 
   beforeEach(() => {
+    req = {
+      sessionModel: {
+        get: sinon.stub()
+      }
+    };
+    res = {};
     locales = {
       a: 'a shallow value',
       b: {


### PR DESCRIPTION
In order to properly support multi-language apps the translate method needs to be read from request, as set by i18n middleware, so it can read the `Accept` language headers from the request to determine the target langauge.

By passing in a static method to these middlewares the only language available is the default fallback language - `en` - and so multi-language support is not possible.

By allowing `req.translate` to be used to perform translations we can then allow non-en languages to be used.