### PR TITLE
Health middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-#ide specific
-.idea/
-
 node_modules
 *.log
 .DS_Store
-doc
-Gemfile.lock
+package-lock.json

--- a/.jscsrc.json
+++ b/.jscsrc.json
@@ -1,6 +1,0 @@
-{
-  "preset": "google",
-  "maximumLineLength": 120,
-  "excludeFiles": ["node_modules/**"],
-  "esnext": true
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '7'
   - '8'
-script:
-  - npm run lint
-  - npm run style
-  - npm test
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -113,3 +113,33 @@ Using the translation key `fields.field-name.label` will return different values
 * If the value of `dependent-field` is `"value-1"` and the value of `dependent-field-2` is `"value-2"`, the label returned will be `"Label 2"`.
 * If the value of `dependent-field` is `"value-2"` the label returned will be `"Label 3"` regardless of the value of `dependent-field-2`
 * The default label `"Fallback label"` will be used if value of `dependent-field` is neither of the given options, or it is `undefined`. It will also be used if the value of `dependent-field` is `"value-1"` and the value of `dependent-field-2` is neither of the given options or it is undefined.
+
+## Health
+
+The health middleware can be used to test API endpoints that have an impact on your HOF service. The health middleware will make a request to each of the health urls and pass an error to the error middleware if one of the API endpoints returns unsuccessfully.
+The health middleware should be used to inform the user that the service is impacted by another API, which makes the service unusable.
+
+### Usage
+
+Add the health endpoint settings to the `hof` options. A `methods` option can be used to set which methods the endpoints should be called on.
+
+```js
+const hof = require('hof');
+
+hof({
+  routes: [
+    ...
+  ],
+  health: [{
+    url: 'https://third.party.api/monitor',
+    methods: ['get']
+  }, {
+    url: 'http://www.example.com/status'
+  }]
+};
+```
+
+### Options
+
+- `url`: The API endpoint url to call. It should not require any parameters. Required.
+- `methods`: An array of method type strings to indicate on which request methods to call the url. Defaults to all. Optional

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const request = require('request-promise-native');
+
+const hasMatchingMethod = (option, reqMethod) => {
+  return option.methods.some(method => {
+    return method.toLowerCase() === reqMethod.toLowerCase();
+  });
+};
+
+module.exports = endpoints => {
+
+  return (req, res, next) => {
+
+    if (endpoints && endpoints.length) {
+
+      let requests = endpoints.reduce((memo, option) => {
+        // Test the method property against the current req method
+        if (option.methods && (hasMatchingMethod(option, req.method) !== true)) {
+          return memo;
+        }
+        // memoize the endpoints
+        memo.push(request(option.url).promise());
+        return memo;
+      }, []);
+
+      // Process all pending requests
+      return Promise.all(requests)
+        .then(() => next())
+        .catch(error => {
+          // Assign a code and let
+          // the error middleware handle it
+          error = new Error(error);
+          error.code = 'UNHEALTHY';
+          next(error);
+        });
+    }
+
+    next();
+  };
+
+};

--- a/package.json
+++ b/package.json
@@ -3,48 +3,36 @@
   "version": "1.1.1",
   "description": "A collection of commonly used HOF middleware",
   "main": "index.js",
-  "license": "GPL-2.0",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/UKHomeOffice/hof-middleware.git"
-  },
-  "bugs": {
-    "url": "https://github.com/UKHomeOffice/hof-middleware/issues"
-  },
-  "homepage": "https://github.com/UKHomeOffice/hof-middleware",
-  "author": "HomeOffice",
+  "license": "MIT",
+  "repository": "https://github.com/UKHomeOfficeForms/hof-middleware.git",
+  "bugs": "https://github.com/UKHomeOfficeForms/hof-middleware/issues",
+  "homepage": "https://github.com/UKHomeOfficeForms/hof-middleware",
+  "author": "UKHomeOfficeForms",
   "scripts": {
-    "test": "NODE_ENV=test mocha",
-    "lint": "eslint .",
-    "style": "jscs **/*.js --config=./.jscsrc.json"
-  },
-  "engines": {
-    "node": ">=4 <5"
+    "test": "npm run unit && npm run lint",
+    "unit": "NODE_ENV=test mocha",
+    "lint": "eslint ."
   },
   "dependencies": {
-    "lodash": "^4.13.1"
+    "lodash": "^4.13.1",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.4"
   },
   "devDependencies": {
     "chai": "^3.0.0",
     "eslint": "^0.23.0",
     "eslint-config-homeoffice": "^0.1.4",
-    "eslint-plugin-filenames": "^0.1.1",
-    "eslint-plugin-mocha": "^0.2.2",
-    "eslint-plugin-one-variable-per-var": "0.0.3",
-    "jscs": "^1.13.1",
     "mocha": "^2.2.5",
-    "mocha-junit-reporter": "^1.4.0",
-    "mocha-multi": "^0.7.1",
     "node-mocks-http": "^1.6.2",
     "pre-commit": "^1.0.10",
+    "proxyquire": "^1.8.0",
     "reqres": "^1.3.0",
     "sinomocha": "^0.2.4",
     "sinon": "^1.15.3",
+    "sinon-as-promised": "^4.0.3",
     "sinon-chai": "^2.8.0"
   },
   "pre-commit": [
-    "lint",
-    "style",
     "test"
   ]
 }

--- a/test/common.js
+++ b/test/common.js
@@ -4,6 +4,7 @@ global.chai = require('chai').use(require('sinon-chai'));
 global.should = chai.should();
 global.sinon = require('sinon');
 require('sinomocha')();
+require('sinon-as-promised');
 
 process.setMaxListeners(0);
 process.stdout.setMaxListeners(0);

--- a/test/lib/health.js
+++ b/test/lib/health.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const proxyquire = require('proxyquire');
+const reqres = require('reqres');
+
+const promiseMatcher = sinon.match(value => {
+  return value instanceof Promise;
+}, 'Not an instance of a Promise');
+
+// Stubbing request promise
+const resolvedPromiseStub = sinon.stub().returns(new Promise(resolve => resolve('pending')));
+const rejectedPromiseStub = sinon.stub().returns(new Promise((resolve, reject) => reject('pending')));
+
+const success = '/success';
+const failure = '/failure';
+
+const requestStub = sinon.stub();
+
+requestStub.withArgs(success).returns({promise: resolvedPromiseStub});
+requestStub.withArgs(failure).returns({promise: rejectedPromiseStub});
+
+const healthMiddleware = proxyquire('../../lib/health', {
+  'request-promise-native': requestStub
+});
+
+
+describe('./lib/health', () => {
+
+  it('returns a middleware function', () => {
+    healthMiddleware().should.be.a('function');
+  });
+
+  describe('middleware', () => {
+
+    const req = reqres.req();
+    const res = reqres.res();
+
+    let middleware;
+
+    beforeEach(() => {
+      sinon.spy(Promise, 'all');
+    });
+
+    afterEach(() => {
+      Promise.all.restore();
+    });
+
+    it('calls next without an error when all health urls are resolved', () => {
+      const options = {
+        health: [{
+          url: success
+        }, {
+          url: success
+        }]
+      };
+
+      middleware = healthMiddleware(options.health);
+
+      return middleware(req, res, (err) => {
+        Promise.all.should.have.been.calledWith([promiseMatcher, promiseMatcher]);
+        should.not.exist(err);
+      });
+    });
+
+    it('calls next with `UNHEALTHY` error if a health url is rejected', () => {
+      const options = {
+        health: [{
+          url: failure
+        }, {
+          url: success
+        }]
+      };
+
+      middleware = healthMiddleware(options.health);
+
+      return middleware(req, res, (err) => {
+        Promise.all.should.have.been.calledWith([promiseMatcher, promiseMatcher]);
+        err.should.be.an.instanceof(Error);
+        err.code.should.equal('UNHEALTHY');
+      });
+    });
+
+    it('accepts a `methods` option', () => {
+      const options = {
+        health: [{
+          url: success,
+          methods: ['get']
+        }, {
+          url: success
+        }]
+      };
+      middleware = healthMiddleware(options.health);
+      req.method = 'GET';
+
+      return middleware(req, res, (err) => {
+        Promise.all.should.have.been.calledWith([promiseMatcher, promiseMatcher]);
+        should.not.exist(err);
+      });
+    });
+
+    it('does not make a request if the `request.method` and endpoint method do not match ', () => {
+      const options = {
+        health: [{
+          url: success,
+          methods: ['get']
+        }, {
+          url: success
+        }]
+      };
+      middleware = healthMiddleware(options.health);
+      req.method = 'POST';
+
+      return middleware(req, res, (err) => {
+        Promise.all.should.have.been.calledWith([promiseMatcher]);
+        should.not.exist(err);
+      });
+    });
+
+  });
+
+});
+


### PR DESCRIPTION
- Inclusion of this middleware will allow a developer to
test the health of one or many API endpoints that their
service may depend on.
- Can be used to send a notification to the client informing
a user of the current status of the service before the user
attempts to complete the form.