### PR TITLE
SD-29: fix cookie check breaking url with query string

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const URI = require('urijs');
+
 module.exports = (options) => {
   const checkName = 'hof-cookie-check';
   const cookieName = (options || {})['cookie-name'] || checkName;
@@ -14,7 +16,8 @@ module.exports = (options) => {
       next(err, req, res, next);
     } else {
       res.cookie(cookieName, 1);
-      res.redirect(req.originalUrl + '?' + encodeURIComponent(paramName));
+      let redirectURL = new URI(req.originalUrl).addQuery(encodeURIComponent(paramName));
+      res.redirect(redirectURL.toString());
     }
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-middleware",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A collection of commonly used HOF middleware",
   "main": "index.js",
   "license": "GPL-2.0",
@@ -19,7 +19,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "lodash": "^4.13.1"
+    "lodash": "^4.13.1",
+    "urijs": "^1.19.2"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/test/lib/cookies.js
+++ b/test/lib/cookies.js
@@ -49,6 +49,15 @@ describe('cookies', () => {
       res.redirect.should.have.been.calledWith('/my-hof-journey?' + encodeURIComponent('hof_param'));
     });
 
+    it('preserves existing query parameters on redirect', () => {
+      req = httpMock.createRequest({
+        method: 'GET',
+        url: '/my-hof-journey?existing-query',
+      });
+      middleware(req, res);
+      res.redirect.should.have.been.calledWith('/my-hof-journey?existing-query&' + encodeURIComponent('hof_param'));
+    });
+
     it('raises an error when a cookie could not be set', () => {
       req.cookies = undefined;
       req.query = {


### PR DESCRIPTION
## What?
Update hof-cookie-check redirect to check if the URL already contains a query string
## Why?
Previously if the hof-cookie-check redirected to a URL that already had a query string it would add it incorrectly. It would add the second query string starting with '?' which breaks the original query string.
## How?
If the redirect URL doesn't have a query string already it adds it normally (starting with ?). If the redirect URL has a query string before the redirect it adds the query string with &, to incorporate both.
## Testing?
Added test to cookie test file