### PR TITLE
Feature/sd 66 restore cookie check except health check

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -3,7 +3,7 @@
 const URI = require('urijs');
 
 const isHealthcheckUrl = (path, healthcheckUrls) => {
-  return healthcheckUrls.some(url=>path.includes(url));
+  return healthcheckUrls.some(url => path.includes(url));
 };
 
 module.exports = (options) => {
@@ -19,16 +19,15 @@ module.exports = (options) => {
   }
 
   return (req, res, next) => {
-    if (req.cookies && Object.keys(req.cookies).length) {
+    const reqIncludesCookies = req.cookies && Object.keys(req.cookies).length;
+    const reqIsCookieCheckRedirect = req.query[paramName] !== undefined;
+
+    if (reqIncludesCookies || isHealthcheckUrl(req.path, healthcheckUrls)) {
       next();
-    } else if (req.cookies === undefined || (!Object.keys(req.cookies).length && req.query[paramName] !== undefined)) {
-      if (isHealthcheckUrl(req.path, healthcheckUrls)) {
-        next();
-      } else {
-        let err = new Error('Cookies required');
-        err.code = 'NO_COOKIES';
-        next(err, req, res, next);
-      }
+    } else if (req.cookies === undefined || (!Object.keys(req.cookies).length && reqIsCookieCheckRedirect)) {
+      let err = new Error('Cookies required');
+      err.code = 'NO_COOKIES';
+      next(err, req, res, next);
     } else {
       res.cookie(cookieName, 1);
       let redirectURL = new URI(req.originalUrl).addQuery(encodeURIComponent(paramName));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-middleware",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A collection of commonly used HOF middleware",
   "main": "index.js",
   "license": "GPL-2.0",


### PR DESCRIPTION
Minor refactor of cookie check revisions. Assign some booleans to named variables for clarity. Also skips redirect on health check urls, rather than redirecting then proceeding.